### PR TITLE
Update requirements.txt

### DIFF
--- a/.travis/requirements.txt
+++ b/.travis/requirements.txt
@@ -2,4 +2,3 @@ pyaml
 jinja2
 pycurl
 gitpython
-salt


### PR DESCRIPTION
adding 'salt' as a requirement didn't fix anything, so out it goes again. 
travis-ci used to work just fine before without 'salt' being a required module.