### PR TITLE
Update npp.sls to ver. 7.1

### DIFF
--- a/npp.sls
+++ b/npp.sls
@@ -1,11 +1,11 @@
-# just 32-bit x86 installer available
+# just 32-bit x86 installer used for now. x64 was introduced at ver. 7.0, but most plugins are still only 32-bit.
 {% if grains['cpuarch'] == 'AMD64' %}
     {% set PROGRAM_FILES = "%ProgramFiles(x86)%" %}
 {% else %}
     {% set PROGRAM_FILES = "%ProgramFiles%" %}
 {% endif %}
 npp:
-  {% for maj_version, f_version, s_version in [('7.x', '7.0', '7')] %}
+  {% for maj_version, f_version, s_version in [('7.x', '7.1', '7.1')] %}
   '{{ s_version }}':
     full_name: 'Notepad++'
     installer: 'https://notepad-plus-plus.org/repository/{{ maj_version }}/{{ f_version }}/npp.{{ s_version }}.Installer.exe'
@@ -15,4 +15,6 @@ npp:
     msiexec: False
     locale: en_US
     reboot: False
- {% endfor %}
+  {% endfor %}
+# the 64-bit installer is available from:
+# https://notepad-plus-plus.org/repository/7.x/7.1/npp.7.1.Installer.x64.exe

--- a/owncloud.sls
+++ b/owncloud.sls
@@ -4,7 +4,7 @@ owncloud:
   {% else %}
     {% set PROGRAM_FILES = "%ProgramFiles%" %}
   {% endif %}
-  {% for version in '2.2.2.6192', '2.2.1.6146', '2.2.0.6076', '2.1.1.5837' %}
+  {% for version in '2.2.4.6408', '2.2.2.6192', '2.2.1.6146', '2.2.0.6076', '2.1.1.5837' %}
   '{{ version }}':
     full_name: 'ownCloud'
     installer: 'https://download.owncloud.com/desktop/stable/ownCloud-{{ version }}-setup.exe'


### PR DESCRIPTION
staying with 32-bit installer for a while yet, almost all of the plugins are still only available as 32-bit versions. the x64 installer was brandew and released for ver. 7.0 